### PR TITLE
fix: pdfjs-dist v5のwebpack互換性問題を解決

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "pnpm install && claude install && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc",
+  "postCreateCommand": "pnpm install && pnpm exec playwright install --with-deps chromium && claude install && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "pnpm install && pnpm exec playwright install --with-deps chromium && claude install && echo 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# 依存関係インストール
+pnpm install
+
+# E2Eテスト用ブラウザ
+pnpm exec playwright install --with-deps chromium
+
+# Claude Code
+claude install
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,11 @@ pnpm knip            # 未使用コード・依存関係の検出
 - Next.js 16 (App Router)
 - React 19 + TypeScript
 - Tailwind CSS
-- pdfjs-dist 4.9.155（PDF.js）
+- pdfjs-dist 5.4.624（PDF.js）
 
 ### 依存関係の注意点
 
-- **pdfjs-dist**: v4.9.155に固定。v5系はNext.js 16との互換性問題があるため使用不可
+- **pdfjs-dist**: v5系。`pdf.mjs`（非minified）は内部にwebpack bootstrapコードを含み、Next.jsのwebpackと衝突するため、`pdfjs-dist/build/pdf.min.mjs`からインポートすること
 - **next dev**: `--webpack`フラグ必須（Turbopackとの互換性問題回避）
 
 ## アーキテクチャ
@@ -66,6 +66,10 @@ pnpm knip            # 未使用コード・依存関係の検出
 ## パスエイリアス
 
 `@/*` → `./src/*`
+
+## CI確認ガイドライン
+
+PR/issueのCI Checksを確認する際は、成否の報告だけでなく、失敗しているジョブがあればログ・詳細を自律的に調査し、原因まで報告すること（ユーザーへの確認は不要）。
 
 ## UI設計ガイドライン
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 - [Next.js](https://nextjs.org/) 16 (App Router)
 - [React](https://react.dev/) 19 + TypeScript
 - [Tailwind CSS](https://tailwindcss.com/) 4
-- [pdfjs-dist](https://mozilla.github.io/pdf.js/) 4.9.155 — PDF描画
+- [pdfjs-dist](https://mozilla.github.io/pdf.js/) 5.4.624 — PDF描画
 - [pdf-lib](https://pdf-lib.js.org/) — AcroForm付きPDF生成
 - [Playwright](https://playwright.dev/) — E2Eテスト
 
@@ -106,7 +106,7 @@ pnpm test:e2e:headed # E2Eテスト（ブラウザ表示付き）
 pnpm knip            # 未使用コード・依存関係の検出
 ```
 
-> **Note:** pdfjs-distはv4.9.155に固定。v5系はNext.js 16との互換性問題あり。devとbuildには`--webpack`フラグが必須（Turbopackとの互換性問題回避）。
+> **Note:** pdfjs-dist v5の`pdf.mjs`は内部にwebpack bootstrapコードを含むため、`pdf.min.mjs`からインポートすること。devとbuildには`--webpack`フラグが必須（Turbopackとの互換性問題回避）。
 
 ## CI
 

--- a/src/hooks/usePdfEditor.ts
+++ b/src/hooks/usePdfEditor.ts
@@ -57,7 +57,7 @@ export function usePdfEditor({ canvasRef, overlayRef }: UsePdfEditorOptions) {
   useEffect(() => {
     const loadPdfjs = async () => {
       try {
-        const pdfjs = await import('pdfjs-dist');
+        const pdfjs = await import('pdfjs-dist/build/pdf.min.mjs');
         pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs';
         setPdfjsLib(pdfjs);
       } catch (error) {

--- a/src/hooks/usePdfEditor.ts
+++ b/src/hooks/usePdfEditor.ts
@@ -25,7 +25,7 @@ function downloadBlob(blob: Blob, filename: string): void {
 export function usePdfEditor({ canvasRef, overlayRef }: UsePdfEditorOptions) {
   const renderTaskRef = useRef<RenderTask | null>(null);
   const [pdfDoc, setPdfDoc] = useState<PDFDocumentProxy | null>(null);
-  const [pdfjsLib, setPdfjsLib] = useState<typeof import('pdfjs-dist') | null>(null);
+  const [pdfjsLib, setPdfjsLib] = useState<typeof import('pdfjs-dist/build/pdf.min.mjs') | null>(null);
   const [currentPage, setCurrentPageRaw] = useState(1);
   const [totalPages, setTotalPages] = useState(0);
   const [scale, setScale] = useState(1.5);

--- a/src/pdfjs-dist.d.ts
+++ b/src/pdfjs-dist.d.ts
@@ -1,0 +1,3 @@
+declare module 'pdfjs-dist/build/pdf.min.mjs' {
+  export * from 'pdfjs-dist';
+}


### PR DESCRIPTION
## Summary

- pdfjs-dist v5.4.624（#47 のDependabot PR）でe2eテストが全滅していた問題を修正
- `pdf.mjs`（非minified）は内部にwebpack bootstrapコード（`__webpack_require__`）を含んでおり、Next.jsのwebpackと衝突してPDF描画が失敗していた
- `pdfjs-dist/build/pdf.min.mjs`からインポートすることで衝突を回避

## Changes

- `src/hooks/usePdfEditor.ts`: インポートパスを `pdfjs-dist` → `pdfjs-dist/build/pdf.min.mjs` に変更
- `src/pdfjs-dist.d.ts`: `pdf.min.mjs`の型宣言ファイルを追加
- `.devcontainer/devcontainer.json`: Playwright Chromiumを`postCreateCommand`に追加
- `CLAUDE.md`: pdfjs-distバージョン・注意点・CI確認ガイドラインを更新

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm lint` 成功
- [x] `pnpm test:e2e` 全37テストパス（7.6秒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)