### PR TITLE
chore: pnpm v10へアップグレードしDevContainer環境を改善

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN corepack enable && corepack prepare pnpm@9 --activate
+ENV HOME=/root
+
+RUN corepack enable && corepack prepare pnpm@10 --activate

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,9 @@
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
+  "remoteEnv": {
+    "PATH": "${containerEnv:HOME}/.local/bin:${containerEnv:PATH}"
+  },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,4 +9,3 @@ pnpm exec playwright install --with-deps chromium
 
 # Claude Code
 claude install
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"
 }


### PR DESCRIPTION
## Summary
- corepackでpnpm@10を使用するようDockerfileを更新
- `packageManager`フィールドを`package.json`に追加してpnpmバージョンを固定
- DevContainerのPATH設定を`.bashrc`への追記からremoteEnvに移動し、より堅牢に
- Dockerfileに明示的な`HOME`環境変数を設定

## Test plan
- [ ] DevContainerが正常にビルドされることを確認
- [ ] `pnpm install`が正常に動作することを確認
- [ ] `pnpm dev`で開発サーバーが起動することを確認
- [ ] Claude Codeのインストールが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)